### PR TITLE
Optimize runtime

### DIFF
--- a/include/mqtt_client/MqttClient.h
+++ b/include/mqtt_client/MqttClient.h
@@ -186,11 +186,11 @@ class MqttClient : public nodelet::Nodelet,
    * - serialized timestamp (optional)
    * - serialized ROS message
    *
-   * The MQTT payload is expected to carry a serialized ROS message.
-   *
-   * @param   mqtt_msg     MQTT message
+   * @param   mqtt_msg       MQTT message
+   * @param   arrival_stamp  arrival timestamp used for latency computation
    */
-  void mqtt2ros(mqtt::const_message_ptr mqtt_msg);
+  void mqtt2ros(mqtt::const_message_ptr mqtt_msg,
+                const ros::WallTime& arrival_stamp = ros::WallTime::now());
 
   /**
    * @brief Callback for when the client has successfully connected to the

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -153,8 +153,9 @@ void MqttClient::loadParameters() {
             }
           }
 
-          NODELET_INFO("Bridging ROS topic '%s' to MQTT topic '%s'",
-                       ros_topic.c_str(), ros2mqtt.mqtt.topic.c_str());
+          NODELET_INFO("Bridging ROS topic '%s' to MQTT topic '%s' %s",
+                       ros_topic.c_str(), ros2mqtt.mqtt.topic.c_str(),
+                       ros2mqtt.stamped ? "and measuring latency" : "");
         } else {
           NODELET_WARN(
             "Parameter 'bridge/ros2mqtt[%d]' is missing subparameter "


### PR DESCRIPTION
- [reuse buffer to avoid copy from MQTT to ROS](https://github.com/ika-rwth-aachen/mqtt_client/commit/80a2a98c04f10a0a7fee75eedf78878309d3bfef)
  - no more `std::memcpy`
  - MQTT payload is reused by ShapeShifter, when ROS message is published
- [optimize serialization to MQTT payload](https://github.com/ika-rwth-aachen/mqtt_client/commit/0693ab7fcec1f7d92b4e1888b8b26911e26f69d5)
  - no more `std::make_move_iterator`
  - payload buffer is allocated with correct size
  - timestamp and ROS message are directly serialized into payload buffer
- [add info message when measuring latency](https://github.com/ika-rwth-aachen/mqtt_client/commit/f1b8903595b2d7ea57489ca62634a869c072bed0)
- [optimize timestamping for latency measurement](https://github.com/ika-rwth-aachen/mqtt_client/commit/9ecb7341327ef736045dfb3d8f34a55f6033066c)
  - departure timestamp is taken as last thing before MQTT publication
  - arrival timestamp is taken as first thing in MQTT arrival callback