### PR TITLE
Fix bug in ros1 latency deserialization

### DIFF
--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -621,7 +621,7 @@ void MqttClient::mqtt2ros(mqtt::const_message_ptr mqtt_msg,
   if (mqtt2ros.stamped) {
 
     // create ROS message buffer on top of MQTT message payload
-    char* non_const_payload = const_cast<char*>(&payload[1]);
+    char* non_const_payload = const_cast<char*>(&payload[msg_offset]);
     uint8_t* stamp_buffer = reinterpret_cast<uint8_t*>(non_const_payload);
 
     // deserialize stamp


### PR DESCRIPTION
- deserialization of message stamp was still expecting the stamp to start at index 1
- this was the behavior before the ros2 refactoring, where the payload still included a bit indicating whether the time stamp was injected
- now, the message type information that is being sent to the other client will include that information
- related to #33 