### PR TITLE
Add CI workflow for automating bloom-release

### DIFF
--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -1,0 +1,20 @@
+name: bloom-release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  bloom-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: at-wat/bloom-release-action@v0
+        with:
+          ros_distro: noetic humble iron rolling
+          github_token_bloom: ${{ secrets.GH_TOKEN_FOR_BLOOM_RELEASE }}
+          github_user: lreiher
+          git_user: Lennart Reiher
+          git_email: lennart.reiher@ika.rwth-aachen.de
+          release_repository_push_url: https://github.com/${{ github.repository }}-release.git
+          open_pr: false


### PR DESCRIPTION
- workflow will run on tag push, e.g. by creating a new GitHub release
- before tagging, version numbers should be bumped and changelog should be prepared (`catkin_generate_changelog`, `catkin_prepare_release`)
- for now, PR in rosdistro should be opened manually