### PR TITLE
Amend AWS IoT CLI command in collect the correct endpoint

### DIFF
--- a/mqtt_client/config/params.aws.yaml
+++ b/mqtt_client/config/params.aws.yaml
@@ -5,7 +5,7 @@ tls_1_2: &tls_1_2 3
 
 broker:
   # YOU MUST CHANGE THIS ENDPOINT
-  # Can be found by executing: aws iot describe-endpoint
+  # Can be found by executing: aws iot describe-endpoint --endpoint-type iot:Data-ATS
   host: not-a-real-endpoint-please-use-your-own.us-west-2.amazonaws.com
   port: 8883
   tls:

--- a/mqtt_client/config/params.ros2.aws.yaml
+++ b/mqtt_client/config/params.ros2.aws.yaml
@@ -2,7 +2,7 @@ mqtt_client:
   ros__parameters:
     broker:
       # YOU MUST CHANGE THIS ENDPOINT
-      # Can be found by executing: aws iot describe-endpoint
+      # Can be found by executing: aws iot describe-endpoint --endpoint-type iot:Data-ATS
       host: not-a-real-endpoint-please-use-your-own.us-west-2.amazonaws.com
       port: 8883
       tls:


### PR DESCRIPTION
modified comments in sample AWS param files to use the correct CLI command to collect the recommended endpoint as per the documentation: https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html