### PR TITLE
JSON support to achieve full integration with non-ROS devices for arbitrary ROS message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,22 +200,9 @@ pose:
     w: 1.0"
 
 # ROS2
-ros2 topic pub /ping/json geometry_msgs/PoseStamped "header:
-  seq: 1
-  stamp:
-    secs: 0
-    nsecs: 0
-  frame_id: 'map'
-pose:
-  position:
-    x: 1.0
-    y: 2.0
-    z: 3.0
-  orientation:
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0"
+
+ros2 topic pub /ping/json geometry_msgs/PoseStamped '{header: {stamp: {sec: 1, nanosec: 50}, frame_id: "map"}, pose: {position: {x: 1.2, y: 3.4, z: 5.6}, orientation: {x: 7.8, y: 0.0, z: 0.0, w: 1.0}}}'
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ pose:
     z: 0.0
     w: 1.0"
 
+# ROS2
+ros2 topic pub /ping/json geometry_msgs/PoseStamped "header:
+  seq: 1
+  stamp:
+    secs: 0
+    nsecs: 0
+  frame_id: 'map'
+pose:
+  position:
+    x: 1.0
+    y: 2.0
+    z: 3.0
+  orientation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0"
+
 ```
 
 ```bash
@@ -206,6 +224,9 @@ pose:
 
 # ROS
 rostopic echo /pong/json
+
+# ROS2
+ros2 topic echo /pong/json
 
 ```
 
@@ -357,6 +378,7 @@ bridge:
     {{ ros_topic_name }}:
       mqtt_topic:          # MQTT topic on which the corresponding ROS messages are sent to the broker
       primitive:           # [false] whether to publish as primitive message
+      json:         # [false] whether message exchanging in in JSON format
       inject_timestamp:    # [false] whether to attach a timestamp to a ROS2MQTT payload (for latency computation on receiver side)
       advanced:
         ros:
@@ -370,6 +392,7 @@ bridge:
     {{ mqtt_topic_name }}:
       ros_topic:           # ROS topic on which corresponding MQTT messages are published
       primitive:           # [false] whether to publish as primitive message (if coming from non-ROS MQTT client)
+      json:         # [false] whether message exchanging in in JSON format
       advanced:
         mqtt:
           qos:               # [0] MQTT QoS value
@@ -387,8 +410,7 @@ If a ROS-to-MQTT transmission is configured as `json`, the message is published 
 
 If an MQTT-to-ROS transmission is configured as `json`, the MQTT message is interpreted as a JSON string and transformed into a ROS message to be published.
 
-The `json` property of both Ros-to-MQTT and MQTT-to-ROS should be equal. Currently this is only supported for ROS, support of ROS2 will come soon.
-
+The `json` property of both Ros-to-MQTT and MQTT-to-ROS should be equal.
 
 ## Primitive Messages
 

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -20,11 +20,14 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(rclcpp REQUIRED)
   find_package(rclcpp_components REQUIRED)
   find_package(std_msgs REQUIRED)
+  find_package(fastcdr REQUIRED)
 
   # Paho MQTT C++ apt package doesn't include CMake config
   # find_package(PahoMqttCpp REQUIRED)
   find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
   find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
+  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../rosx_introspection/include)
+  set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   add_library(${PROJECT_NAME}_lib SHARED src/MqttClient.ros2.cpp)
 
@@ -35,11 +38,15 @@ if(${ROS_VERSION} EQUAL 2)
 
   target_include_directories(${PROJECT_NAME}_lib PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+    $<INSTALL_INTERFACE:include>
+    ${ROSX_INTROSPECTION_INCLUDE_DIR}
+    )
 
   target_link_libraries(${PROJECT_NAME}_lib
     ${PahoMqttC_LIBRARY}
     ${PahoMqttCpp_LIBRARY}
+    ${rox_introspection_LIBRARY}
+    fastcdr
   )
 
   ament_target_dependencies(${PROJECT_NAME}_lib
@@ -95,13 +102,14 @@ elseif(${ROS_VERSION} EQUAL 1)
     rosfmt ## For fmt::format.
     std_msgs
     topic_tools
-    ros_msg_parser
   )
 
   ## System dependencies are found with CMake's conventions
   find_package(PahoMqttCpp REQUIRED)
   set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
-
+  find_package(fastcdr REQUIRED)
+  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rosx_introspection/include)
+  set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   ## Uncomment this if the package has a setup.py. This macro ensures
   ## modules and global scripts declared therein get installed
@@ -207,6 +215,7 @@ elseif(${ROS_VERSION} EQUAL 1)
   include_directories(
     include
     ${catkin_INCLUDE_DIRS}
+    ${ROSX_INTROSPECTION_INCLUDE_DIR}
   )
 
   ## Declare a C++ library
@@ -238,7 +247,9 @@ elseif(${ROS_VERSION} EQUAL 1)
   target_link_libraries(${PROJECT_NAME}
     ${catkin_LIBRARIES}
     ${PahoMqttCpp_LIBRARIES}
-  )
+    ${rox_introspection_LIBRARY}
+    fastcdr
+    )
 
   #############
   ## Install ##

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -26,7 +26,7 @@ if(${ROS_VERSION} EQUAL 2)
   # find_package(PahoMqttCpp REQUIRED)
   find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
   find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
-  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../rosx_introspection/include)
+  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rosx_introspection/include)
   set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   add_library(${PROJECT_NAME}_lib SHARED src/MqttClient.ros2.cpp)

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -19,6 +19,8 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(mqtt_client_interfaces REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rclcpp_components REQUIRED)
+  find_package(rosbag2_cpp REQUIRED)
+  find_package(rosidl_typesupport_cpp REQUIRED)
   find_package(std_msgs REQUIRED)
   find_package(fastcdr REQUIRED)
 
@@ -26,7 +28,7 @@ if(${ROS_VERSION} EQUAL 2)
   # find_package(PahoMqttCpp REQUIRED)
   find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
   find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
-  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../rosx_introspection/include)
+  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rosx_introspection/include)
   set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   add_library(${PROJECT_NAME}_lib SHARED src/MqttClient.ros2.cpp)
@@ -54,6 +56,8 @@ if(${ROS_VERSION} EQUAL 2)
     mqtt_client_interfaces
     rclcpp
     rclcpp_components
+    rosbag2_cpp
+    rosidl_typesupport_cpp
     std_msgs
   )
 

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -95,6 +95,7 @@ elseif(${ROS_VERSION} EQUAL 1)
     rosfmt ## For fmt::format.
     std_msgs
     topic_tools
+    ros_msg_parser
   )
 
   ## System dependencies are found with CMake's conventions

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -23,13 +23,12 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(rosidl_typesupport_cpp REQUIRED)
   find_package(std_msgs REQUIRED)
   find_package(fastcdr REQUIRED)
+  find_package(rosx_introspection REQUIRED)
 
   # Paho MQTT C++ apt package doesn't include CMake config
   # find_package(PahoMqttCpp REQUIRED)
   find_library(PahoMqttC_LIBRARY libpaho-mqtt3as.so.1 REQUIRED)
   find_library(PahoMqttCpp_LIBRARY libpaho-mqttpp3.so.1 REQUIRED)
-  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rosx_introspection/include)
-  set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   add_library(${PROJECT_NAME}_lib SHARED src/MqttClient.ros2.cpp)
 
@@ -41,14 +40,15 @@ if(${ROS_VERSION} EQUAL 2)
   target_include_directories(${PROJECT_NAME}_lib PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
-    ${ROSX_INTROSPECTION_INCLUDE_DIR}
+    ${rosx_introspection_INCLUDE_DIRS}
     )
 
   target_link_libraries(${PROJECT_NAME}_lib
     ${PahoMqttC_LIBRARY}
     ${PahoMqttCpp_LIBRARY}
-    ${rox_introspection_LIBRARY}
+    ${rosx_introspection_LIBRARIES}
     fastcdr
+    
   )
 
   ament_target_dependencies(${PROJECT_NAME}_lib
@@ -59,6 +59,7 @@ if(${ROS_VERSION} EQUAL 2)
     rosbag2_cpp
     rosidl_typesupport_cpp
     std_msgs
+    rosx_introspection
   )
 
   install(TARGETS ${PROJECT_NAME}_lib
@@ -106,14 +107,13 @@ elseif(${ROS_VERSION} EQUAL 1)
     rosfmt ## For fmt::format.
     std_msgs
     topic_tools
+    rosx_introspection
   )
 
   ## System dependencies are found with CMake's conventions
   find_package(PahoMqttCpp REQUIRED)
   set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
   find_package(fastcdr REQUIRED)
-  set(ROSX_INTROSPECTION_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rosx_introspection/include)
-  set(rox_introspection_LIBRARY ${ROSX_INTROSPECTION_INCLUDE_DIR}/../build/librosx_introspection.a)
 
   ## Uncomment this if the package has a setup.py. This macro ensures
   ## modules and global scripts declared therein get installed
@@ -219,7 +219,6 @@ elseif(${ROS_VERSION} EQUAL 1)
   include_directories(
     include
     ${catkin_INCLUDE_DIRS}
-    ${ROSX_INTROSPECTION_INCLUDE_DIR}
   )
 
   ## Declare a C++ library
@@ -251,7 +250,6 @@ elseif(${ROS_VERSION} EQUAL 1)
   target_link_libraries(${PROJECT_NAME}
     ${catkin_LIBRARIES}
     ${PahoMqttCpp_LIBRARIES}
-    ${rox_introspection_LIBRARY}
     fastcdr
     )
 

--- a/mqtt_client/config/params.ros2.yaml
+++ b/mqtt_client/config/params.ros2.yaml
@@ -9,8 +9,10 @@ mqtt_client:
           - /ping/ros
         /ping/ros:
           mqtt_topic: pingpong/ros
+          json: true
       mqtt2ros:
         mqtt_topics: 
           - pingpong/ros
         pingpong/ros:
           ros_topic: /pong/ros
+          json: true

--- a/mqtt_client/config/params.yaml
+++ b/mqtt_client/config/params.yaml
@@ -5,12 +5,14 @@ bridge:
   ros2mqtt:
     - ros_topic: /ping/ros
       mqtt_topic: pingpong/ros
+      json: true
     - ros_topic: /ping/primitive
       mqtt_topic: pingpong/primitive
       primitive: true
   mqtt2ros:
     - mqtt_topic: pingpong/ros
       ros_topic: /pong/ros
+      json: true
     - mqtt_topic: pingpong/primitive
       ros_topic: /pong/primitive
       primitive: true

--- a/mqtt_client/config/params.yaml
+++ b/mqtt_client/config/params.yaml
@@ -5,6 +5,8 @@ bridge:
   ros2mqtt:
     - ros_topic: /ping/ros
       mqtt_topic: pingpong/ros
+    - ros_topic: /ping/json
+      mqtt_topic: pingpong/json
       json: true
     - ros_topic: /ping/primitive
       mqtt_topic: pingpong/primitive
@@ -12,6 +14,8 @@ bridge:
   mqtt2ros:
     - mqtt_topic: pingpong/ros
       ros_topic: /pong/ros
+    - mqtt_topic: pingpong/json
+      ros_topic: /pong/json
       json: true
     - mqtt_topic: pingpong/primitive
       ros_topic: /pong/primitive

--- a/mqtt_client/include/mqtt_client/MqttClient.h
+++ b/mqtt_client/include/mqtt_client/MqttClient.h
@@ -37,7 +37,7 @@ SOFTWARE.
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
 #include <rosfmt/full.h> // fmt::format, fmt::join
-#include <ros_msg_parser/ros_parser.hpp>
+#include <rosx_introspection/ros_parser.hpp>
 #include <topic_tools/shape_shifter.h>
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
@@ -389,8 +389,8 @@ class MqttClient : public nodelet::Nodelet,
     bool primitive = false;   ///< whether to publish as primitive message
     bool json = false;        ///< whether the serial messages flowing through MQTT
                               ///< broker are JSON format
-    std::shared_ptr< RosMsgParser::Parser> json_parser;  ///< parser from json to ROS message and vice-versa
-
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;  ///< parser from json to ROS message and vice-versa
+    
 
     bool stamped = false;  ///< whether to inject timestamp in MQTT message
   };
@@ -414,7 +414,7 @@ class MqttClient : public nodelet::Nodelet,
                              ///< coming from non-ROS MQTT client)
     bool json = false;  ///< whether the serial messages flowing through MQTT
                         ///< broker are JSON format
-    std::shared_ptr< RosMsgParser::Parser> json_parser;   ///< parser from json to ROS message and vice-versa
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;   ///< parser from json to ROS message and vice-versa
 
     bool stamped = false;  ///< whether timestamp is injected
   };

--- a/mqtt_client/include/mqtt_client/MqttClient.ros2.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.ros2.hpp
@@ -42,6 +42,7 @@ SOFTWARE.
 #include <rclcpp/serialization.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <rosx_introspection/ros_parser.hpp>
+#include "rosx_introspection/ros_utils/ros2_helpers.hpp"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
@@ -409,7 +410,7 @@ class MqttClient : public rclcpp::Node,
     bool primitive = false;   ///< whether to publish as primitive message
     bool json = false;        ///< whether the serial messages flowing through MQTT
                               ///< broker are JSON format
-    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;  ///< parser from json to ROS message and vice-versa
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS2_Deserializer>> json_parser;  ///< parser from json to ROS message and vice-versa
     bool stamped = false;     ///< whether to inject timestamp in MQTT message
   };
 
@@ -434,7 +435,7 @@ class MqttClient : public rclcpp::Node,
                              ///< coming from non-ROS MQTT client)
     bool json = false;  ///< whether the serial messages flowing through MQTT
                         ///< broker are JSON format
-    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;   ///< parser from json to ROS message and vice-versa
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS2_Deserializer>> json_parser;   ///< parser from json to ROS message and vice-versa
     bool stamped = false;    ///< whether timestamp is injected
   };
 

--- a/mqtt_client/include/mqtt_client/MqttClient.ros2.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.ros2.hpp
@@ -41,7 +41,10 @@ SOFTWARE.
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
 #include <std_msgs/msg/float64.hpp>
-
+#include <rosx_introspection/ros_parser.hpp>
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
 /**
  * @brief Namespace for the mqtt_client package
@@ -404,6 +407,9 @@ class MqttClient : public rclcpp::Node,
       bool retained = false;  ///< whether to retain MQTT message
     } mqtt;                   ///< MQTT-related variables
     bool primitive = false;   ///< whether to publish as primitive message
+    bool json = false;        ///< whether the serial messages flowing through MQTT
+                              ///< broker are JSON format
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;  ///< parser from json to ROS message and vice-versa
     bool stamped = false;     ///< whether to inject timestamp in MQTT message
   };
 
@@ -426,6 +432,9 @@ class MqttClient : public rclcpp::Node,
     } ros;                   ///< ROS-related variables
     bool primitive = false;  ///< whether to publish as primitive message (if
                              ///< coming from non-ROS MQTT client)
+    bool json = false;  ///< whether the serial messages flowing through MQTT
+                        ///< broker are JSON format
+    std::shared_ptr< RosMsgParser::ParsersCollection<RosMsgParser::ROS_Deserializer>> json_parser;   ///< parser from json to ROS message and vice-versa
     bool stamped = false;    ///< whether timestamp is injected
   };
 

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -29,6 +29,8 @@
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
   <depend condition="$ROS_VERSION == 2">rcpputils</depend>
+  <depend condition="$ROS_VERSION == 2">rosbag2_cpp</depend>
+  <depend condition="$ROS_VERSION == 2">rosidl_typesupport_cpp</depend>
 
   <!-- ROS1 -->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -20,6 +20,7 @@
   <depend>mqtt_client_interfaces</depend>
   <depend>ros_environment</depend>
   <depend>std_msgs</depend>
+  <depend>rosx_introspection</depend>
 
   <!-- ROS2 -->
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -235,6 +235,10 @@ void MqttClient::loadParameters() {
           if (ros2mqtt_params[k].hasMember("primitive"))
             ros2mqtt.primitive = ros2mqtt_params[k]["primitive"];
 
+          // ros2mqtt[k]/json
+          if (ros2mqtt_params[k].hasMember("json"))
+            ros2mqtt.json = ros2mqtt_params[k]["json"];
+
           // ros2mqtt[k]/inject_timestamp
           if (ros2mqtt_params[k].hasMember("inject_timestamp"))
             ros2mqtt.stamped = ros2mqtt_params[k]["inject_timestamp"];
@@ -294,6 +298,10 @@ void MqttClient::loadParameters() {
           // mqtt2ros[k]/primitive
           if (mqtt2ros_params[k].hasMember("primitive"))
             mqtt2ros.primitive = mqtt2ros_params[k]["primitive"];
+
+          // mqtt2ros[k]/json
+          if (mqtt2ros_params[k].hasMember("json"))
+            mqtt2ros.json = mqtt2ros_params[k]["json"];
 
           // mqtt2ros[k]/advanced
           if (mqtt2ros_params[k].hasMember("advanced")) {
@@ -504,7 +512,65 @@ void MqttClient::ros2mqtt(const topic_tools::ShapeShifter::ConstPtr& ros_msg,
   NODELET_DEBUG("Received ROS message of type '%s' on topic '%s'",
                 ros_msg_type.name.c_str(), ros_topic.c_str());
 
-  if (ros2mqtt.primitive) {  // publish as primitive (string) message
+  if (ros2mqtt.json) {
+
+
+    // if ROS message type has changed
+    if (ros_msg_type.md5 !=
+        mqtt2ros_[ros2mqtt.mqtt.topic].ros.shape_shifter.getMD5Sum()) {
+
+      Mqtt2RosInterface& mqtt2ros = mqtt2ros_[ros2mqtt.mqtt.topic];
+
+      NODELET_INFO("ROS publisher message type on topic '%s' set to '%s'",
+                   mqtt2ros.ros.topic.c_str(), ros_msg_type.name.c_str());
+
+      // configure ShapeShifter
+      mqtt2ros.ros.shape_shifter.morph(ros_msg_type.md5, ros_msg_type.name,
+                                       ros_msg_type.definition, "");
+
+      // advertise with ROS publisher
+      mqtt2ros.ros.publisher.shutdown();
+      mqtt2ros.ros.publisher = mqtt2ros.ros.shape_shifter.advertise(
+        node_handle_, mqtt2ros.ros.topic, mqtt2ros.ros.queue_size,
+        mqtt2ros.ros.latched);
+
+      // subscribe to MQTT topic with actual ROS messages
+      client_->subscribe(ros2mqtt.mqtt.topic, mqtt2ros.mqtt.qos);
+
+
+      // configure json parser
+      ros2mqtt.json_parser = std::make_shared<RosMsgParser::Parser>(ros_topic, ros_msg_type.name, ros_msg_type.definition);
+
+      mqtt2ros_[ros2mqtt.mqtt.topic].json_parser = ros2mqtt.json_parser;
+    }
+
+    // deserialize the shapeshifter message into json
+    std::vector<uint8_t> tmp_buffer;
+    std::string payload;
+    tmp_buffer.resize(ros_msg->size());
+    ros::serialization::OStream stream(tmp_buffer.data(), tmp_buffer.size());
+    ros_msg->write(stream);
+    ros2mqtt.json_parser->deserializeIntoJson(
+      RosMsgParser::Span<uint8_t>(tmp_buffer), &payload, false, false, false);
+
+    // parse the created json string from format {topic:{t} , msg: {m}} into {m}
+    size_t startIdx = payload.find("msg");
+    if (startIdx != std::string::npos) {
+      startIdx += 6;  // Move past "(msg:)"
+      size_t endIdx = payload.rfind("}");
+      if (endIdx != std::string::npos)
+        payload = "{" + payload.substr(startIdx, endIdx - startIdx);
+      else
+        NODELET_ERROR("not the expected json format");
+    } else
+      NODELET_ERROR("not the expected json format");
+
+    // serialize the json string into payload_buffer
+    payload_buffer = std::vector<uint8_t>(payload.begin(), payload.end());
+  }
+
+
+  else if (ros2mqtt.primitive) {  // publish as primitive (string) message
 
     // resolve ROS messages to primitive strings if possible
     std::string payload;
@@ -606,7 +672,7 @@ void MqttClient::ros2mqtt(const topic_tools::ShapeShifter::ConstPtr& ros_msg,
 
 void MqttClient::mqtt2ros(mqtt::const_message_ptr mqtt_msg,
                           const ros::WallTime& arrival_stamp) {
-
+  
   std::string mqtt_topic = mqtt_msg->get_topic();
   Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_topic];
   auto& payload = mqtt_msg->get_payload_ref();
@@ -652,19 +718,37 @@ void MqttClient::mqtt2ros(mqtt::const_message_ptr mqtt_msg,
     msg_length -= stamp_length;
     msg_offset += stamp_length;
   }
+  if (mqtt2ros.json) {
+    // the message is a serialized json string
+    std::vector<uint8_t> msg_buffer;
+    std::string msgStr = mqtt_msg->get_payload_str();
 
-  // create ROS message buffer on top of MQTT message payload
-  char* non_const_payload = const_cast<char*>(&payload[msg_offset]);
-  uint8_t* msg_buffer = reinterpret_cast<uint8_t*>(non_const_payload);
-  ros::serialization::OStream msg_stream(msg_buffer, msg_length);
+    // convert json into a serialized ROS message, using the json_parser object
+    mqtt2ros.json_parser->serializeFromJson(msg_buffer, &msgStr);
+    ros::serialization::OStream msg_stream(&msg_buffer[0], msg_buffer.size());
+    // publish via ShapeShifter
+    NODELET_DEBUG(
+      "Sending ROS message of type '%s' from MQTT broker to ROS topic '%s' ...",
+      mqtt2ros.ros.shape_shifter.getDataType().c_str(),
+      mqtt2ros.ros.topic.c_str());
 
-  // publish via ShapeShifter
-  NODELET_DEBUG(
-    "Sending ROS message of type '%s' from MQTT broker to ROS topic '%s' ...",
-    mqtt2ros.ros.shape_shifter.getDataType().c_str(),
-    mqtt2ros.ros.topic.c_str());
-  mqtt2ros.ros.shape_shifter.read(msg_stream);
-  mqtt2ros.ros.publisher.publish(mqtt2ros.ros.shape_shifter);
+    mqtt2ros.ros.shape_shifter.read(msg_stream);
+    mqtt2ros.ros.publisher.publish(mqtt2ros.ros.shape_shifter);
+  }
+
+  else {  // create ROS message buffer on top of MQTT message payload
+    char* non_const_payload = const_cast<char*>(&payload[msg_offset]);
+    uint8_t* msg_buffer = reinterpret_cast<uint8_t*>(non_const_payload);
+    ros::serialization::OStream msg_stream(msg_buffer, msg_length);
+
+    // publish via ShapeShifter
+    NODELET_DEBUG(
+      "Sending ROS message of type '%s' from MQTT broker to ROS topic '%s' ...",
+      mqtt2ros.ros.shape_shifter.getDataType().c_str(),
+      mqtt2ros.ros.topic.c_str());
+    mqtt2ros.ros.shape_shifter.read(msg_stream);
+    mqtt2ros.ros.publisher.publish(mqtt2ros.ros.shape_shifter);
+  }
 }
 
 


### PR DESCRIPTION
This PR integrates functionality for a full communication with other (non-mqtt_client) MQTT clients. Unlike the current feature of exchanging primitive messages, this feature allows ROS-based devices to exchange arbitrary messages with devices not based on ROS. It works in both directions, where a non-ROS-based device can send a JSON string that will be casted into a ROS message in runtime.

The PR is based on my updates to [ros_msg_parser](https://github.com/ahmad-ra/ros_msg_parser) package that uses shapeshifter to provide type introspection in ROS, my contribution was to update the parser class to convert a JSON string into a serialized ROS message, achieving bi-directional parsing capabilities between JSON <-> ROS-msg.

The README is updated to explain the new functionality, and its demo and technical details are added in the corresponding sections.

This PR should close #9 and set the ground ready for working on #18.

-   Subscribe any (non-ROS-based) MQTT message and publish it as a ROS message.
-   Subscribe any ROS message  and publish it as a JSON string payload through MQTT, ready to be interpreted by other MQTT clients.
 
