### PR TITLE
Make ROS/ROS2 node name configurable via launch file

### DIFF
--- a/mqtt_client/config/params.ros2.yaml
+++ b/mqtt_client/config/params.ros2.yaml
@@ -1,4 +1,4 @@
-mqtt_client:
+/**/*:
   ros__parameters:
     broker:
       host: localhost

--- a/mqtt_client/launch/standalone.launch
+++ b/mqtt_client/launch/standalone.launch
@@ -1,9 +1,10 @@
 <launch>
 
-  <arg name="params_file" default="$(find mqtt_client)/config/params.yaml" />
+  <arg name="namespace" default="mqtt_client" />
   <arg name="node_name" default="mqtt_client" />
+  <arg name="params_file" default="$(find mqtt_client)/config/params.yaml" />
 
-  <node pkg="nodelet" type="nodelet" name="$(arg node_name)" args="standalone mqtt_client/MqttClient" output="screen">
+  <node pkg="nodelet" type="nodelet" name="$(arg node_name)" ns="$(arg namespace)" args="standalone mqtt_client/MqttClient" output="screen">
     <rosparam command="load" file="$(arg params_file)" />
   </node>
 

--- a/mqtt_client/launch/standalone.launch
+++ b/mqtt_client/launch/standalone.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="namespace" default="mqtt_client" />
+  <arg name="namespace" default="/" />
   <arg name="node_name" default="mqtt_client" />
   <arg name="params_file" default="$(find mqtt_client)/config/params.yaml" />
 

--- a/mqtt_client/launch/standalone.launch
+++ b/mqtt_client/launch/standalone.launch
@@ -1,8 +1,9 @@
 <launch>
 
   <arg name="params_file" default="$(find mqtt_client)/config/params.yaml" />
+  <arg name="node_name" default="mqtt_client" />
 
-  <node pkg="nodelet" type="nodelet" name="mqtt_client" args="standalone mqtt_client/MqttClient" output="screen">
+  <node pkg="nodelet" type="nodelet" name="$(arg node_name)" args="standalone mqtt_client/MqttClient" output="screen">
     <rosparam command="load" file="$(arg params_file)" />
   </node>
 

--- a/mqtt_client/launch/standalone.launch.ros2.xml
+++ b/mqtt_client/launch/standalone.launch.ros2.xml
@@ -1,9 +1,10 @@
 <launch>
 
-  <arg name="params_file" default="$(find-pkg-share mqtt_client)/config/params.ros2.yaml" />
+  <arg name="namespace" default="mqtt_client" />
   <arg name="node_name" default="mqtt_client" />
+  <arg name="params_file" default="$(find-pkg-share mqtt_client)/config/params.ros2.yaml" />
 
-  <node pkg="mqtt_client" exec="mqtt_client" name="$(var node_name)" output="screen">
+  <node pkg="mqtt_client" exec="mqtt_client" name="$(var node_name)" namespace="$(var namespace)" output="screen">
     <param from="$(var params_file)" />
   </node>
 

--- a/mqtt_client/launch/standalone.launch.ros2.xml
+++ b/mqtt_client/launch/standalone.launch.ros2.xml
@@ -1,8 +1,9 @@
 <launch>
 
   <arg name="params_file" default="$(find-pkg-share mqtt_client)/config/params.ros2.yaml" />
+  <arg name="node_name" default="mqtt_client" />
 
-  <node pkg="mqtt_client" exec="mqtt_client" name="mqtt_client" output="screen">
+  <node pkg="mqtt_client" exec="mqtt_client" name="$(var node_name)" output="screen">
     <param from="$(var params_file)" />
   </node>
 

--- a/mqtt_client/launch/standalone.launch.ros2.xml
+++ b/mqtt_client/launch/standalone.launch.ros2.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="namespace" default="mqtt_client" />
+  <arg name="namespace" default="" />
   <arg name="node_name" default="mqtt_client" />
   <arg name="params_file" default="$(find-pkg-share mqtt_client)/config/params.ros2.yaml" />
 


### PR DESCRIPTION
Implementation to make ROS/ROS2 node name configurable via launch file.

To be considered when using ROS2:

The node name has to be considered [here](https://github.com/ika-rwth-aachen/mqtt_client/blob/main/mqtt_client/config/params.ros2.yaml#L1) in the params file (e.g. [params.ros2.yaml](https://github.com/ika-rwth-aachen/mqtt_client/blob/main/mqtt_client/config/params.ros2.yaml)). Thus, when renaming the ROS2 node via the launch argument, a new config file has to be applied (with a modified entry considering the updated node name).