### PR TITLE
Use system version of libfmt instead of rosfmt vendored one on ROS 1

### DIFF
--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -92,7 +92,6 @@ elseif(${ROS_VERSION} EQUAL 1)
     mqtt_client_interfaces
     nodelet
     roscpp
-    rosfmt ## For fmt::format.
     std_msgs
     topic_tools
   )
@@ -100,6 +99,9 @@ elseif(${ROS_VERSION} EQUAL 1)
   ## System dependencies are found with CMake's conventions
   find_package(PahoMqttCpp REQUIRED)
   set(PahoMqttCpp_LIBRARIES PahoMqttCpp::paho-mqttpp3)
+
+  find_package(fmt REQUIRED)
+  set(fmt_LIBRARIES fmt::fmt)
 
 
   ## Uncomment this if the package has a setup.py. This macro ensures
@@ -194,7 +196,9 @@ elseif(${ROS_VERSION} EQUAL 1)
       roscpp
       std_msgs
       topic_tools
-    DEPENDS PahoMqttCpp
+    DEPENDS
+      fmt
+      PahoMqttCpp
   )
 
   ###########
@@ -236,6 +240,7 @@ elseif(${ROS_VERSION} EQUAL 1)
   ## Specify libraries to link a library or executable target against
   target_link_libraries(${PROJECT_NAME}
     ${catkin_LIBRARIES}
+    ${fmt_LIBRARIES}
     ${PahoMqttCpp_LIBRARIES}
   )
 

--- a/mqtt_client/include/mqtt_client/MqttClient.h
+++ b/mqtt_client/include/mqtt_client/MqttClient.h
@@ -32,11 +32,11 @@ SOFTWARE.
 #include <memory>
 #include <string>
 
+#include <fmt/format.h>
 #include <mqtt_client_interfaces/IsConnected.h>
 #include <mqtt/async_client.h>
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
-#include <rosfmt/full.h> // fmt::format, fmt::join
 #include <topic_tools/shape_shifter.h>
 
 

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -17,13 +17,13 @@
   <author email="bastian.lampe@rwth-aachen.de">Bastian Lampe</author>
   <author email="christian.wende@rwth-aachen.de">Christian Wende</author>
 
+  <depend>fmt</depend>
   <depend>mqtt_client_interfaces</depend>
   <depend>ros_environment</depend>
   <depend>std_msgs</depend>
 
   <!-- ROS2 -->
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
-  <depend condition="$ROS_VERSION == 2">fmt</depend>
   <depend condition="$ROS_VERSION == 2">libpaho-mqtt-dev</depend>
   <depend condition="$ROS_VERSION == 2">libpaho-mqttpp-dev</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
@@ -35,7 +35,6 @@
   <depend condition="$ROS_VERSION == 1">nodelet</depend>
   <depend condition="$ROS_VERSION == 1">paho-mqtt-cpp</depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
-  <depend condition="$ROS_VERSION == 1">rosfmt</depend>
   <depend condition="$ROS_VERSION == 1">topic_tools</depend>
 
   <export>


### PR DESCRIPTION
Including this package on a ROS Noetic setup where other packages use system `libfmt-dev` causes xqms/rosfmt#12 to break them. 

We're dropping mqtt from our setup for different reasons, so this isn't exhaustively tested. But in case it helps, these changes drop `rosfmt` in favor of system `libfmt-dev` and the package still builds on Noetic, which is the only version this is released into. A simple test run of the nodelet also seems to format error messages just fine.
