### PR TITLE
Add Parameter to Disable Verification of Server Certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ client:
     version:              # TLS version (https://github.com/eclipse/paho.mqtt.cpp/blob/master/src/mqtt/ssl_options.h#L305)
     verify:               # verify the client should conduct post-connect checks.
     alpn_protos:          # list of ALPN protocols (https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_alpn_protos.html)
+    server_cert_auth:     # [true] whether to verify the server certificate
 ```
 
 #### Bridge Parameters

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -423,6 +423,7 @@ class MqttClient : public rclcpp::Node,
       int version;                           ///< TLS version (https://github.com/eclipse/paho.mqtt.cpp/blob/master/src/mqtt/ssl_options.h#L305)
       bool verify;                           ///< Verify the client should conduct
                                              ///< post-connect checks
+      bool server_cert_auth;                 ///< whether to verify the server certificate
       std::vector<std::string> alpn_protos;  ///< list of ALPN protocols
     } tls;                                   ///< SSL/TLS-related variables
   };

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -309,6 +309,8 @@ void MqttClient::loadParameters() {
   declare_parameter("client.tls.key", rclcpp::ParameterType::PARAMETER_STRING, param_desc);
   param_desc.description = "client private key password";
   declare_parameter("client.tls.password", rclcpp::ParameterType::PARAMETER_STRING, param_desc);
+  param_desc.description = "whether to verify the server certificate";
+  declare_parameter("client.tls.server_cert_auth", rclcpp::ParameterType::PARAMETER_BOOL, param_desc);
 
   param_desc.description = "The list of topics to bridge from ROS to MQTT";
   const auto ros2mqtt_ros_topics = declare_parameter<std::vector<std::string>>("bridge.ros2mqtt.ros_topics", std::vector<std::string>(), param_desc);
@@ -398,6 +400,7 @@ void MqttClient::loadParameters() {
       loadParameter("client.tls.verify", client_config_.tls.verify);
       loadParameter("client.tls.alpn_protos", client_config_.tls.alpn_protos);
     }
+    loadParameter("client.tls.server_cert_auth", client_config_.tls.server_cert_auth, true);
   }
 
   // resolve filepaths
@@ -886,6 +889,7 @@ void MqttClient::setupClient() {
       if (!client_config_.tls.password.empty())
         ssl.set_private_key_password(client_config_.tls.password);
     }
+    ssl.set_enable_server_cert_auth(client_config_.tls.server_cert_auth);
     ssl.set_ssl_version(client_config_.tls.version);
     ssl.set_verify(client_config_.tls.verify);
     ssl.set_alpn_protos(client_config_.tls.alpn_protos);


### PR DESCRIPTION
This PR introduces a new boolean `client.tls.server_cert_auth` ROS parameter (`true` by default) to optionally disable verification of the server certificate. This is helpful in case the MQTT broker uses a self-signed certificate, which cannot be verified at the client side. The implementation uses the [set_enable_server_cert_auth](https://eclipse.dev/paho/files/cppdoc/classmqtt_1_1ssl__options.html#ad9ae3ac9f11beb1303522c92c2241550) method of the Eclipse Paho MQTT C++ Client Library (see also [code on GitHub](https://github.com/eclipse-paho/paho.mqtt.cpp/blob/55833eb9fb1bf602158d26fffb982a5f0345f77e/src/ssl_options.cpp#L258)). Closes #86.