### PR TITLE
JSON message bridging

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,28 +89,40 @@ The *mqtt_client* is best configured with a ROS parameter *yaml* file. The confi
 - MQTT messages received from the broker on MQTT topic `pingpong/json` are received as JSON and published locally as a ROS message on ROS topic `/pong/json`;
 
 ```yaml
-broker:
-  host: localhost
-  port: 1883
-bridge:
-  ros2mqtt:
-    - ros_topic: /ping/ros
-      mqtt_topic: pingpong/ros
-    - ros_topic: /ping/primitive
-      mqtt_topic: pingpong/primitive
-      primitive: true
-    - ros_topic: /ping/json
-      mqtt_topic: pingpong/json
-      json: true
-  mqtt2ros:
-    - mqtt_topic: pingpong/ros
-      ros_topic: /pong/ros
-    - mqtt_topic: pingpong/primitive
-      ros_topic: /pong/primitive
-      primitive: true
-    - mqtt_topic: pingpong/json
-      ros_topic: /pong/json
-      json: true
+/**/*:
+  ros__parameters:
+    broker:
+      host: localhost
+      port: 1883
+    bridge:
+      ros2mqtt:
+        ros_topics:
+          - /ping/ros
+          - /ping/primitive
+          - /ping/json
+        /ping/ros:
+          mqtt_topic: pingpong/ros
+        /ping/primitive:
+          mqtt_topic: pingpong/primitive
+          primitive: true
+        /ping/json:
+          mqtt_topic: pingpong/json
+          ros_type: std_msgs/msg/Header
+          json: true
+      mqtt2ros:
+        mqtt_topics:
+          - pingpong/ros
+          - pingpong/primitive
+          - pingpong/json
+        pingpong/ros:
+          ros_topic: /pong/ros
+        pingpong/primitive:
+          ros_topic: /pingpong/primitive
+          primitive: true
+        pingpong/json:
+          ros_topic: /pingpong/json
+          ros_type: std_msgs/msg/Header
+          json: true
 ```
 
 #### Demo Client Launch
@@ -122,18 +134,23 @@ ros2 launch mqtt_client standalone.launch.xml
 ```
 
 ```txt
-[ WARN] [1665575657.358869079]: Parameter 'broker/tls/enabled' not set, defaulting to '0'
-[ WARN] [1665575657.359798329]: Parameter 'client/id' not set, defaulting to ''
-[ WARN] [1665575657.359810889]: Client buffer can not be enabled when client ID is empty
-[ WARN] [1665575657.360300703]: Parameter 'client/clean_session' not set, defaulting to '1'
-[ WARN] [1665575657.360576344]: Parameter 'client/keep_alive_interval' not set, defaulting to '60.000000'
-[ WARN] [1665575657.360847295]: Parameter 'client/max_inflight' not set, defaulting to '65535'
-[ INFO] [1665575657.361281461]: Bridging ROS topic '/ping/ros' to MQTT topic 'pingpong/ros'
-[ INFO] [1665575657.361303380]: Bridging primitive ROS topic '/ping/primitive' to MQTT topic 'pingpong/primitive'
-[ INFO] [1665575657.361352809]: Bridging MQTT topic 'pingpong/ros' to ROS topic '/pong/ros'
-[ INFO] [1665575657.361370558]: Bridging MQTT topic 'pingpong/primitive' to primitive ROS topic '/pong/primitive'
-[ INFO] [1665575657.362153083]: Connecting to broker at 'tcp://localhost:1883' ...
-[ INFO] [1665575657.462622065]: Connected to broker at 'tcp://localhost:1883'
+[WARN] [1784177470.554584791] [mqtt_client]: Parameter 'broker.tls.enabled' not set, defaulting to '0'
+[WARN] [1784177470.554598993] [mqtt_client]: Parameter 'client.id' not set, defaulting to ''
+[WARN] [1784177470.554601539] [mqtt_client]: Client buffer can not be enabled when client ID is empty
+[WARN] [1784177470.554603583] [mqtt_client]: Parameter 'client.clean_session' not set, defaulting to '1'
+[WARN] [1784177470.554608214] [mqtt_client]: Parameter 'client.keep_alive_interval' not set, defaulting to '60.000000'
+[WARN] [1784177470.554614310] [mqtt_client]: Parameter 'client.max_inflight' not set, defaulting to '65535'
+[INFO] [1784177470.554618910] [mqtt_client]: Bridging ROS topic '/ping/ros' to MQTT topic 'pingpong/ros'
+[INFO] [1784177470.554624122] [mqtt_client]: Bridging primitive ROS topic '/ping/primitive' to MQTT topic 'pingpong/primitive'
+[INFO] [1784177470.554628131] [mqtt_client]: Bridging ROS topic '/ping/json' to MQTT topic 'pingpong/json' as json string
+[INFO] [1784177470.554631865] [mqtt_client]: Bridging MQTT topic '/pong/ros' to ROS topic 'pingpong/ros'
+[INFO] [1784177470.554635680] [mqtt_client]: Bridging MQTT topic '/pong/primitive' to primitive ROS topic 'pingpong/primitive'
+[INFO] [1784177470.554639351] [mqtt_client]: Bridging MQTT topic '/pong/json' containing json messages to ROS topic 'pingpong/json'
+[INFO] [1784177470.555223971] [mqtt_client]: Connecting to broker at 'tcp://localhost:1883' ...
+[INFO] [1784177470.555884138] [mqtt_client]: Connected to broker at 'tcp://localhost:1883'
+[INFO] [1784177470.555922224] [mqtt_client]: Subscribed MQTT topic '/pong/json'
+[INFO] [1784177470.555938736] [mqtt_client]: Subscribed MQTT topic '/pong/primitive'
+[INFO] [1784177470.555955462] [mqtt_client]: Subscribed MQTT topic 'mqtt_client/ros_msg_type//pong/ros'
 ```
 
 Note that the *mqtt_client* successfully connected to the broker and also echoed which ROS/MQTT topics are being bridged. For testing the communication between *mqtt_client*, itself, and other MQTT clients, open five new terminals.
@@ -170,6 +187,30 @@ ros2 topic echo /pong/primitive
 ```bash
 # 5th terminal: publish primitive MQTT message to pingpong/primitive directly using mosquitto_pub
 docker run --rm --network host eclipse-mosquitto mosquitto_pub -h localhost -t "pingpong/primitive" --repeat 20 --repeat-delay 1 -m 69
+```
+
+If everything works as expected, the second terminal should print a message at 1Hz, while the fourth terminal should print two different messages at 1Hz.
+
+In order to test the communication between *mqtt_client* and other MQTT clients over JSON, publish a ROS message on ROS topic `/ping/json`, publish a json formatted MQTT message on MQTT topic `pingpong/json` and wait for responses on ROS topic `/pong/json`. Note that you need to restart the ROS 2 *mqtt_client* with a different config file. This example uses [`std_msgs/Header`](http://docs.ros.org/en/api/std_msgs/html/msg/Header.html), it can be any locally available message type, but a ros_type must be set in the parameter file or similar.
+
+```bash
+# mqtt_client$
+ros2 launch mqtt_client standalone.launch.xml params_file:=$(ros2 pkg prefix mqtt_client)/share/mqtt_client/config/params.json.yaml
+```
+
+```bash
+# 3rd terminal: publish ROS header message to /ping/json
+ros2 topic pub /ping/json std_msgs/msg/Header "{stamp: \"now\", frame_id: \"ros\"}"
+```
+
+```bash
+# 4th terminal: listen for ROS messages on /pong/json
+ros2 topic echo /pong/json
+```
+
+```bash
+# 5th terminal: publish json MQTT message to pingpong/json directly using mosquitto_pub
+docker run --rm --network host eclipse-mosquitto mosquitto_pub -h localhost -t "pingpong/json" --repeat 20 --repeat-delay 1 -m '{"stamp":{"sec":123,"nanosec":456789},"frame_id":"mqtt"}'
 ```
 
 If everything works as expected, the second terminal should print a message at 1Hz, while the fourth terminal should print two different messages at 1Hz.
@@ -284,7 +325,7 @@ If a ROS-to-MQTT transmission is configured as `json`, the message is published 
 
 If an MQTT-to-ROS transmission is configured as `json`, the MQTT message is interpreted as a JSON string and transformed into a ROS message to be published.
 
-The `json` property of both Ros-to-MQTT and MQTT-to-ROS should be equal.
+The `json` property of both ROS-to-MQTT and MQTT-to-ROS bridges require that the 'ros_type' property is also defined as it does not support dynamic type deduction.
 
 ## Primitive Messages
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/ika-rwth-aachen/mqtt_client"><img src="https://img.shields.io/github/stars/ika-rwth-aachen/mqtt_client?style=social"/></a>
 </p>
 
-The *mqtt_client* package provides a ROS 2 component node that enables connected ROS-based devices or robots to exchange ROS messages via an MQTT broker using the [MQTT](http://mqtt.org) protocol. This works generically for arbitrary ROS message types. The *mqtt_client* can also exchange primitive messages with MQTT clients running on devices not based on ROS.
+The *mqtt_client* package provides a ROS 2 component node that enables connected ROS-based and non-ROS-based devices or robots to exchange ROS messages via an MQTT broker using the [MQTT](http://mqtt.org) protocol. This works generically for arbitrary ROS message types. The *mqtt_client* can also exchange primitive messages or messages formatted as JSON with MQTT clients running on devices not based on ROS.
 
 > [!IMPORTANT]  
 > This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).  
@@ -23,6 +23,7 @@ The *mqtt_client* package provides a ROS 2 component node that enables connected
   - [Quick Start](#quick-start)
   - [Launch](#launch)
   - [Configuration](#configuration)
+- [JSON Messages](#json-messages)
 - [Primitive Messages](#primitive-messages)
 - [Latency Computation](#latency-computation)
 - [Package Summary](#package-summary)
@@ -84,6 +85,8 @@ The *mqtt_client* is best configured with a ROS parameter *yaml* file. The confi
 - MQTT messages received from the broker on MQTT topic `pingpong/ros` are published locally on ROS topic `/pong/ros`;
 - primitive ROS messages received locally on ROS topic `/ping/primitive` are sent as primitive (string) messages to the broker on MQTT topic `pingpong/primitive`;
 - MQTT messages received from the broker on MQTT topic `pingpong/primitive` are published locally as primitive ROS messages on ROS topic `/pong/primitive`.
+- ROS messages received locally on ROS topic `/ping/json` are sent to the broker in JSON format on MQTT topic `pingpong/json`;
+- MQTT messages received from the broker on MQTT topic `pingpong/json` are received as JSON and published locally as a ROS message on ROS topic `/pong/json`;
 
 ```yaml
 broker:
@@ -96,12 +99,18 @@ bridge:
     - ros_topic: /ping/primitive
       mqtt_topic: pingpong/primitive
       primitive: true
+    - ros_topic: /ping/json
+      mqtt_topic: pingpong/json
+      json: true
   mqtt2ros:
     - mqtt_topic: pingpong/ros
       ros_topic: /pong/ros
     - mqtt_topic: pingpong/primitive
       ros_topic: /pong/primitive
       primitive: true
+    - mqtt_topic: pingpong/json
+      ros_topic: /pong/json
+      json: true
 ```
 
 #### Demo Client Launch
@@ -234,6 +243,7 @@ bridge:
     {{ ros_topic_name }}:
       mqtt_topic:          # MQTT topic on which the corresponding ROS messages are sent to the broker
       primitive:           # [false] whether to publish as primitive message
+      json:                # [false] whether message exchanging is in JSON format
       ros_type:            # [*empty*] If set, the ROS msg type provided will be used. If empty, the type is automatically deduced via the publisher
       inject_timestamp:    # [false] whether to attach a timestamp to a ROS2MQTT payload (for latency computation on receiver side)
       advanced:
@@ -252,6 +262,7 @@ bridge:
       ros_topic:           # ROS topic on which corresponding MQTT messages are published
       ros_type:            # [*empty*] If set, the ROS msg type provided will be used. If empty, the type is automatically deduced via the MQTT message
       primitive:           # [false] whether to publish as primitive message (if coming from non-ROS MQTT client)
+      json:                # [false] whether message exchanging is in JSON format
       advanced:
         mqtt:
           qos:             # [0] MQTT QoS value
@@ -263,9 +274,21 @@ bridge:
             durability:    # [system_default] One of "system_default", "volatile", "transient_local". 
 ```
 
+
+## JSON Messages
+
+As seen in the [Quick Start](#quick-start), the *mqtt_client* can not only exchange arbitrary ROS messages with other *mqtt_clients*, but it can also exchange arbitrary messages with other non-*mqtt_client* MQTT clients using JSON. This allows ROS-based devices to exchange ROS messages with devices not based on ROS.
+Non-*mqtt_client* MQTT clients can send a JSON string with a format that matches the needed ROS message to be cast into. The `json` parameter can be set for both ROS-to-MQTT (`bridge/ros2mqtt`) and for MQTT-to-ROS (`bridge/mqtt2ros`) transmissions.
+
+If a ROS-to-MQTT transmission is configured as `json`, the message is published as a serialized JSON string.
+
+If an MQTT-to-ROS transmission is configured as `json`, the MQTT message is interpreted as a JSON string and transformed into a ROS message to be published.
+
+The `json` property of both Ros-to-MQTT and MQTT-to-ROS should be equal.
+
 ## Primitive Messages
 
-As seen in the [Quick Start](#quick-start), the *mqtt_client* can not only exchange arbitrary ROS messages with other *mqtt_clients*, but it can also exchange primitive message data with other non-*mqtt_client* MQTT clients. This allows ROS-based devices to exchange primitive messages with devices not based on ROS. The `primitive` parameter can be set for both ROS-to-MQTT (`bridge/ros2mqtt`) and for MQTT-to-ROS (`bridge/mqtt2ros`) transmissions.
+Additionally, the *mqtt_client* can also exchange primitive message data with other non-*mqtt_client* MQTT clients. This allows ROS-based devices to exchange primitive messages with devices not based on ROS. The `primitive` parameter can be set for both ROS-to-MQTT (`bridge/ros2mqtt`) and for MQTT-to-ROS (`bridge/mqtt2ros`) transmissions.
 
 If a ROS-to-MQTT transmission is configured as `primitive` and the ROS message type is one of the supported primitive ROS message types, the raw data is published as a string. The supported primitive ROS message types are [`std_msgs/String`](http://docs.ros.org/en/api/std_msgs/html/msg/String.html), [`std_msgs/Bool`](http://docs.ros.org/en/api/std_msgs/html/msg/Bool.html), [`std_msgs/Char`](http://docs.ros.org/en/api/std_msgs/html/msg/Char.html), [`std_msgs/UInt8`](http://docs.ros.org/en/api/std_msgs/html/msg/UInt8.html), [`std_msgs/UInt16`](http://docs.ros.org/en/api/std_msgs/html/msg/UInt16.html), [`std_msgs/UInt32`](http://docs.ros.org/en/api/std_msgs/html/msg/UInt32.html), [`std_msgs/UInt64`](http://docs.ros.org/en/api/std_msgs/html/msg/UInt64.html), [`std_msgs/Int8`](http://docs.ros.org/en/api/std_msgs/html/msg/Int8.html), [`std_msgs/Int16`](http://docs.ros.org/en/api/std_msgs/html/msg/Int16.html), [`std_msgs/Int32`](http://docs.ros.org/en/api/std_msgs/html/msg/Int32.html), [`std_msgs/Int64`](http://docs.ros.org/en/api/std_msgs/html/msg/Int64.html), [`std_msgs/Float32`](http://docs.ros.org/en/api/std_msgs/html/msg/Float32.html), [`std_msgs/Float64`](http://docs.ros.org/en/api/std_msgs/html/msg/Float64.html), [`std_msgs/UInt8MultiArray`](http://docs.ros.org/en/api/std_msgs/html/msg/UInt8MultiArray.html).
 

--- a/mqtt_client/CMakeLists.txt
+++ b/mqtt_client/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(fmt REQUIRED)
 find_package(mqtt_client_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rosx_introspection REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # Paho MQTT C++ apt package doesn't include CMake config
@@ -41,6 +42,7 @@ target_link_libraries(${PROJECT_NAME}_lib
   rclcpp::rclcpp
   rclcpp_components::component
   ${std_msgs_TARGETS}
+  ${rosx_introspection_TARGETS}
 )
 
 install(TARGETS ${PROJECT_NAME}_lib

--- a/mqtt_client/config/params.json.yaml
+++ b/mqtt_client/config/params.json.yaml
@@ -1,0 +1,20 @@
+/**/*:
+  ros__parameters:
+    broker:
+      host: localhost
+      port: 1883
+    bridge:
+      ros2mqtt:
+        ros_topics:
+          - /ping/json
+        /ping/json:
+          mqtt_topic: pingpong/json
+          ros_type: std_msgs/msg/Header
+          json: true
+      mqtt2ros:
+        mqtt_topics:
+          - pingpong/json
+        pingpong/json:
+          ros_topic: /pong/json
+          ros_type: std_msgs/msg/Header
+          json: true

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -44,6 +44,7 @@ SOFTWARE.
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/qos.hpp>
 #include <std_msgs/msg/float64.hpp>
+#include "rosx_introspection/ros_parser.hpp"
 
 
 /**
@@ -447,6 +448,7 @@ class MqttClient : public rclcpp::Node,
     struct {
       rclcpp::GenericSubscription::SharedPtr
         subscriber;          ///< generic ROS subscriber
+      std::shared_ptr<RosMsgParser::Parser> parser;   ///< Message parser for JSON conversion
       std::string msg_type;  ///< message type of subscriber
       int queue_size = 1;    ///< ROS subscriber queue size
       bool is_stale = false; ///< whether a new generic publisher/subscriber is required
@@ -480,6 +482,7 @@ class MqttClient : public rclcpp::Node,
       rclcpp::GenericPublisher::SharedPtr publisher;  ///< generic ROS publisher
       rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr
         latency_publisher;   ///< ROS publisher for latency
+      std::shared_ptr<RosMsgParser::Parser> parser;   ///< Message parser for JSON conversion
       int queue_size = 1;    ///< ROS publisher queue size
       struct {
         rclcpp::ReliabilityPolicy reliability = rclcpp::ReliabilityPolicy::SystemDefault;

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -452,6 +452,7 @@ class MqttClient : public rclcpp::Node,
     } mqtt;                   ///< MQTT-related variables
     bool fixed_type = false;  ///< whether the published message type is specified explicitly
     bool primitive = false;   ///< whether to publish as primitive message
+    bool json = false;        ///< whether to publish as json string
     bool stamped = false;     ///< whether to inject timestamp in MQTT message
   };
 

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -43,8 +43,8 @@ SOFTWARE.
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/qos.hpp>
+#include <rosx_introspection/ros_parser.hpp>
 #include <std_msgs/msg/float64.hpp>
-#include "rosx_introspection/ros_parser.hpp"
 
 
 /**

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -271,6 +271,17 @@ class MqttClient : public rclcpp::Node,
                 const rclcpp::Time& arrival_stamp);
 
   /**
+   * @brief Publishes a ROS message received via MQTT in JSON format to ROS.
+   *
+   * This utilizes the generic publisher stored for the MQTT topic on which the
+   * message was received. The publisher has to be configured to the ROS message
+   * type of the message.
+   *
+   * @param   mqtt_msg       MQTT message
+   */
+  void mqttjson2ros(mqtt::const_message_ptr mqtt_msg);
+
+  /**
    * @brief Publishes a primitive message received via MQTT to ROS.
    *
    * @param   mqtt_msg     MQTT message

--- a/mqtt_client/include/mqtt_client/MqttClient.hpp
+++ b/mqtt_client/include/mqtt_client/MqttClient.hpp
@@ -480,6 +480,8 @@ class MqttClient : public rclcpp::Node,
     bool fixed_type = false; ///< whether the published ros message type is specified explicitly
     bool primitive = false;  ///< whether to publish as primitive message (if
                              ///< coming from non-ROS MQTT client)
+    bool json = false;       ///< whether to parse as json message (if
+                             ///< coming from non-ROS MQTT client)
     bool stamped = false;    ///< whether timestamp is injected
   };
 

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -24,6 +24,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>libpaho-mqtt-dev</depend>
   <depend>libpaho-mqttpp-dev</depend>
+  <depend>rosx_introspection</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rcpputils</depend>

--- a/mqtt_client/package.xml
+++ b/mqtt_client/package.xml
@@ -24,10 +24,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>libpaho-mqtt-dev</depend>
   <depend>libpaho-mqttpp-dev</depend>
-  <depend>rosx_introspection</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rcpputils</depend>
+  <depend>rosx_introspection</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -1542,15 +1542,15 @@ void MqttClient::message_arrived(mqtt::const_message_ptr mqtt_msg) {
                 &(payload[0]), payload_length);
     serialized_ros_msg_type.get_rcl_serialized_message().buffer_length = payload_length;
 
+    // deserialize ROS message type
+    mqtt_client_interfaces::msg::RosMsgType ros_msg_type;
+    deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
+
     // reconstruct corresponding MQTT data topic
     std::string mqtt_data_topic = mqtt_topic;
     mqtt_data_topic.erase(mqtt_data_topic.find(kRosMsgTypeMqttTopicPrefix),
                           kRosMsgTypeMqttTopicPrefix.length());
     Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_data_topic];
-
-    // deserialize ROS message type
-    mqtt_client_interfaces::msg::RosMsgType ros_msg_type;
-    deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
 
     // if ROS message type has changed or if mapping is stale
     if (ros_msg_type.name != mqtt2ros.ros.msg_type || mqtt2ros.ros.is_stale) {

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -50,6 +50,8 @@ SOFTWARE.
 #include <std_msgs/msg/u_int8.hpp>
 #include <std_msgs/msg/u_int8_multi_array.hpp>
 
+#include "rosx_introspection/ros_parser.hpp"
+#include "rosx_introspection/ros_utils/ros2_helpers.hpp"
 #include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(mqtt_client::MqttClient)
 
@@ -1002,6 +1004,20 @@ void MqttClient::ros2mqtt(
                   ros_msg_type.name.c_str());
       return;
     }
+
+  } else if (ros2mqtt.json) {  // publish as json string
+
+    // resolve ROS messages to primitive strings if possible
+    RosMsgParser::Parser parser(ros_topic, RosMsgParser::ROSType(ros2mqtt.ros.msg_type), RosMsgParser::GetMessageDefinition(ros2mqtt.ros.msg_type));
+    RosMsgParser::NanoCDR_Deserializer deserializer;
+    RosMsgParser::Span<const unsigned char> data{
+        reinterpret_cast<const unsigned char*>(serialized_msg->get_rcl_serialized_message().buffer),
+        serialized_msg->size()
+    };
+
+    std::string payload;
+    parser.deserializeIntoJson(data, &payload, &deserializer);
+    payload_buffer = std::vector<uint8_t>(payload.begin(), payload.end());
 
   } else {  // publish as complete ROS message incl. ROS message type
 

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -464,6 +464,13 @@ void MqttClient::loadParameters() {
         RCLCPP_DEBUG(get_logger(), "Using explicit ROS message type '%s'", ros2mqtt.ros.msg_type.c_str());
       }
 
+      if (ros2mqtt.json && !ros2mqtt.fixed_type) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "ROS topic '%s' configured to publish as JSON must have a type configured", ros_topic.c_str());
+        exit(EXIT_FAILURE);
+      }
+
       // ros2mqtt[k]/inject_timestamp
       rclcpp::Parameter stamped_param;
       if (get_parameter(fmt::format("bridge.ros2mqtt.{}.inject_timestamp", ros_topic), stamped_param))
@@ -580,6 +587,13 @@ void MqttClient::loadParameters() {
         mqtt2ros.ros.msg_type = ros_type_param.as_string();
         mqtt2ros.fixed_type = true;
         RCLCPP_DEBUG(get_logger(), "Using explicit ROS message type '%s' for '%s'", mqtt2ros.ros.msg_type.c_str(), ros_topic.c_str());
+      }
+
+      if (mqtt2ros.json && !mqtt2ros.fixed_type) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "MQTT topic '%s' configured to be read as JSON must have a type configured", mqtt_topic.c_str());
+        exit(EXIT_FAILURE);
       }
 
       // mqtt2ros[k]/advanced/mqtt/qos
@@ -1376,7 +1390,7 @@ void MqttClient::connected(const std::string& cause) {
 
   // subscribe MQTT topics
   for (const auto& [mqtt_topic, mqtt2ros] : mqtt2ros_) {
-    if (!mqtt2ros.primitive) {
+    if (!mqtt2ros.primitive && !mqtt2ros.json) {
       std::string const mqtt_topic_to_subscribe = kRosMsgTypeMqttTopicPrefix + mqtt_topic;
       client_->subscribe(mqtt_topic_to_subscribe, mqtt2ros.mqtt.qos);
       RCLCPP_INFO(get_logger(), "Subscribed MQTT topic '%s'", mqtt_topic_to_subscribe.c_str());
@@ -1530,11 +1544,7 @@ void MqttClient::message_arrived(mqtt::const_message_ptr mqtt_msg) {
 
     // deserialize ROS message type
     mqtt_client_interfaces::msg::RosMsgType ros_msg_type;
-    if (!mqtt2ros.json) {
-        deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
-    } else {
-        ros_msg_type.name = mqtt_msg->get_payload();
-    }
+    deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
 
     // if ROS message type has changed or if mapping is stale
     if (ros_msg_type.name != mqtt2ros.ros.msg_type || mqtt2ros.ros.is_stale) {

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -331,6 +331,8 @@ void MqttClient::loadParameters() {
     declare_parameter(fmt::format("bridge.ros2mqtt.{}.mqtt_topic", ros_topic), rclcpp::ParameterType::PARAMETER_STRING, param_desc);
     param_desc.description = "whether to publish as primitive message";
     declare_parameter(fmt::format("bridge.ros2mqtt.{}.primitive", ros_topic), rclcpp::ParameterType::PARAMETER_BOOL, param_desc);
+    param_desc.description = "whether to publish as json string";
+    declare_parameter(fmt::format("bridge.ros2mqtt.{}.json", ros_topic), rclcpp::ParameterType::PARAMETER_BOOL, param_desc);
     param_desc.description = "If set, the ROS msg type provided will be used. If empty, the type is automatically deduced via the publisher";
     declare_parameter(fmt::format("bridge.ros2mqtt.{}.ros_type", ros_topic), rclcpp::ParameterType::PARAMETER_STRING, param_desc);
     param_desc.description = "whether to attach a timestamp to a ROS2MQTT payload (for latency computation on receiver side)";
@@ -438,6 +440,18 @@ void MqttClient::loadParameters() {
       if (get_parameter(fmt::format("bridge.ros2mqtt.{}.primitive", ros_topic), primitive_param))
         ros2mqtt.primitive = primitive_param.as_bool();
 
+      // ros2mqtt[k]/json
+      rclcpp::Parameter json_param;
+      if (get_parameter(fmt::format("bridge.ros2mqtt.{}.json", ros_topic), json_param))
+        ros2mqtt.json = json_param.as_bool();
+      if (ros2mqtt.primitive && ros2mqtt.json) {
+        RCLCPP_WARN(
+          get_logger(),
+          "Primitive ROS topic '%s' will not be published as json string",
+          ros_topic.c_str());
+        ros2mqtt.json = false;
+      }
+
       // ros2mqtt[k]/ros_type
       rclcpp::Parameter ros_type_param;
       if (get_parameter(fmt::format("bridge.ros2mqtt.{}.ros_type", ros_topic), ros_type_param)) {
@@ -454,6 +468,14 @@ void MqttClient::loadParameters() {
         RCLCPP_WARN(
           get_logger(),
           "Timestamp will not be injected into primitive messages on ROS "
+          "topic '%s'",
+          ros_topic.c_str());
+        ros2mqtt.stamped = false;
+      }
+      if (ros2mqtt.stamped && ros2mqtt.json) {
+        RCLCPP_WARN(
+          get_logger(),
+          "Timestamp will not be injected into json string messages on ROS "
           "topic '%s'",
           ros_topic.c_str());
         ros2mqtt.stamped = false;
@@ -509,9 +531,10 @@ void MqttClient::loadParameters() {
       if (get_parameter(fmt::format("bridge.ros2mqtt.{}.advanced.mqtt.retained", ros_topic), retained_param))
         ros2mqtt.mqtt.retained = retained_param.as_bool();
 
-      RCLCPP_INFO(get_logger(), "Bridging %sROS topic '%s' to MQTT topic '%s' %s",
+      RCLCPP_INFO(get_logger(), "Bridging %sROS topic '%s' to MQTT topic '%s' %s%s",
                   ros2mqtt.primitive ? "primitive " : "", ros_topic.c_str(),
                   ros2mqtt.mqtt.topic.c_str(),
+                  ros2mqtt.json ? "as json string" : "",
                   ros2mqtt.stamped ? "and measuring latency" : "");
     } else {
       RCLCPP_WARN(get_logger(),

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -1177,6 +1177,28 @@ void MqttClient::mqtt2ros(mqtt::const_message_ptr mqtt_msg,
   mqtt2ros.ros.publisher->publish(serialized_msg);
 }
 
+void MqttClient::mqttjson2ros(mqtt::const_message_ptr mqtt_msg) {
+  std::string mqtt_topic = mqtt_msg->get_topic();
+  Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_topic];
+
+  RosMsgParser::Parser parser(mqtt2ros.ros.topic, RosMsgParser::ROSType(mqtt2ros.ros.msg_type), RosMsgParser::GetMessageDefinition(mqtt2ros.ros.msg_type));
+  RosMsgParser::ROS2_Serializer serializer;
+  parser.serializeFromJson(mqtt_msg->get_payload(), &serializer);
+  uint32_t msg_length = serializer.getBufferSize();
+
+  // copy ROS message from MQTT message to generic message buffer
+  rclcpp::SerializedMessage serialized_msg(msg_length);
+  std::memcpy(serialized_msg.get_rcl_serialized_message().buffer,
+              (serializer.getBufferData()), msg_length);
+  serialized_msg.get_rcl_serialized_message().buffer_length = msg_length;
+
+  // publish generic ROS message
+  RCLCPP_DEBUG(
+    get_logger(),
+    "Sending ROS message of type '%s' from MQTT broker to ROS topic '%s' ...",
+    mqtt2ros.ros.msg_type.c_str(), mqtt2ros.ros.topic.c_str());
+  mqtt2ros.ros.publisher->publish(serialized_msg);
+}
 
 void MqttClient::mqtt2primitive(mqtt::const_message_ptr mqtt_msg) {
 
@@ -1462,7 +1484,7 @@ void MqttClient::message_arrived(mqtt::const_message_ptr mqtt_msg) {
   RCLCPP_DEBUG(get_logger(), "Received MQTT message on topic '%s'",
                mqtt_topic.c_str());
 
-  // publish directly if primitive
+  // publish directly if format is primitive or json
   if (mqtt2ros_.count(mqtt_topic) > 0) {
     Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_topic];
 
@@ -1472,6 +1494,9 @@ void MqttClient::message_arrived(mqtt::const_message_ptr mqtt_msg) {
       } else {
         mqtt2primitive(mqtt_msg);
       }
+      return;
+    } else if (mqtt2ros.json) {
+      mqttjson2ros(mqtt_msg);
       return;
     }
   }
@@ -1489,15 +1514,19 @@ void MqttClient::message_arrived(mqtt::const_message_ptr mqtt_msg) {
                 &(payload[0]), payload_length);
     serialized_ros_msg_type.get_rcl_serialized_message().buffer_length = payload_length;
 
-    // deserialize ROS message type
-    mqtt_client_interfaces::msg::RosMsgType ros_msg_type;
-    deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
-
     // reconstruct corresponding MQTT data topic
     std::string mqtt_data_topic = mqtt_topic;
     mqtt_data_topic.erase(mqtt_data_topic.find(kRosMsgTypeMqttTopicPrefix),
                           kRosMsgTypeMqttTopicPrefix.length());
     Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_data_topic];
+
+    // deserialize ROS message type
+    mqtt_client_interfaces::msg::RosMsgType ros_msg_type;
+    if (!mqtt2ros.json) {
+        deserializeRosMessage(serialized_ros_msg_type, ros_msg_type);
+    } else {
+        ros_msg_type.name = mqtt_msg->get_payload();
+    }
 
     // if ROS message type has changed or if mapping is stale
     if (ros_msg_type.name != mqtt2ros.ros.msg_type || mqtt2ros.ros.is_stale) {

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -359,6 +359,8 @@ void MqttClient::loadParameters() {
     declare_parameter(fmt::format("bridge.mqtt2ros.{}.ros_topic", mqtt_topic), rclcpp::ParameterType::PARAMETER_STRING, param_desc);
     param_desc.description = "whether to publish as primitive message (if coming from non-ROS MQTT client)";
     declare_parameter(fmt::format("bridge.mqtt2ros.{}.primitive", mqtt_topic), rclcpp::ParameterType::PARAMETER_BOOL, param_desc);
+    param_desc.description = "whether to parse as json message (if coming from non-ROS MQTT client)";
+    declare_parameter(fmt::format("bridge.mqtt2ros.{}.json", mqtt_topic), rclcpp::ParameterType::PARAMETER_BOOL, param_desc);
     param_desc.description = "If set, the ROS msg type provided will be used. If empty, the type is automatically deduced via the MQTT message";
     declare_parameter(fmt::format("bridge.mqtt2ros.{}.ros_type", mqtt_topic), rclcpp::ParameterType::PARAMETER_STRING, param_desc);
     param_desc.description = "MQTT QoS value";
@@ -561,6 +563,17 @@ void MqttClient::loadParameters() {
       if (get_parameter(fmt::format("bridge.mqtt2ros.{}.primitive", mqtt_topic), primitive_param))
         mqtt2ros.primitive = primitive_param.as_bool();
 
+      // mqtt2ros[k]/json
+      rclcpp::Parameter json_param;
+      if (get_parameter(fmt::format("bridge.mqtt2ros.{}.json", mqtt_topic), json_param))
+        mqtt2ros.json = json_param.as_bool();
+      if (mqtt2ros.primitive && mqtt2ros.json) {
+        RCLCPP_WARN(
+          get_logger(),
+          "Primitive MQTT topic '%s' will not be parsed as json string",
+          mqtt_topic.c_str());
+        mqtt2ros.json = false;
+      }
 
       rclcpp::Parameter ros_type_param;
       if (get_parameter(fmt::format("bridge.mqtt2ros.{}.ros_type", mqtt_topic), ros_type_param)) {
@@ -620,8 +633,9 @@ void MqttClient::loadParameters() {
                     "since ROS 2 does not easily support latched topics.", mqtt_topic).c_str());
       }
 
-      RCLCPP_INFO(get_logger(), "Bridging MQTT topic '%s' to %sROS topic '%s'",
-                  mqtt_topic.c_str(), mqtt2ros.primitive ? "primitive " : "",
+      RCLCPP_INFO(get_logger(), "Bridging MQTT topic '%s' %sto %sROS topic '%s'",
+                  mqtt_topic.c_str(), mqtt2ros.json ? "containing json messages " : "",
+                  mqtt2ros.primitive ? "primitive " : "",
                   mqtt2ros.ros.topic.c_str());
     }
     else {

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -1205,7 +1205,13 @@ void MqttClient::mqttjson2ros(mqtt::const_message_ptr mqtt_msg) {
 
 
   RosMsgParser::ROS2_Serializer serializer;
-  mqtt2ros.ros.parser->serializeFromJson(mqtt_msg->get_payload(), &serializer);
+  try {
+    mqtt2ros.ros.parser->serializeFromJson(mqtt_msg->get_payload(), &serializer);
+  } catch (const std::runtime_error& e) {
+    RCLCPP_ERROR(get_logger(), "Failed to parse MQTT message on topic '%s' configured as JSON string of type %s. Message received: '%s'", mqtt_topic.c_str(), mqtt2ros.ros.msg_type.c_str(), mqtt_msg->get_payload().c_str());
+    return;
+  }
+
   uint32_t msg_length = serializer.getBufferSize();
 
   // copy ROS message from MQTT message to generic message buffer

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -542,11 +542,11 @@ void MqttClient::loadParameters() {
       if (get_parameter(fmt::format("bridge.ros2mqtt.{}.advanced.mqtt.retained", ros_topic), retained_param))
         ros2mqtt.mqtt.retained = retained_param.as_bool();
 
-      RCLCPP_INFO(get_logger(), "Bridging %sROS topic '%s' to MQTT topic '%s' %s%s",
+      RCLCPP_INFO(get_logger(), "Bridging %sROS topic '%s' to MQTT topic '%s'%s%s",
                   ros2mqtt.primitive ? "primitive " : "", ros_topic.c_str(),
                   ros2mqtt.mqtt.topic.c_str(),
-                  ros2mqtt.json ? "as json string" : "",
-                  ros2mqtt.stamped ? "and measuring latency" : "");
+                  ros2mqtt.json ? " as json string" : "",
+                  ros2mqtt.stamped ? " and measuring latency" : "");
     } else {
       RCLCPP_WARN(get_logger(),
                   fmt::format("Parameter 'bridge.ros2mqtt.{}' is missing subparameter "

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -1021,8 +1021,11 @@ void MqttClient::ros2mqtt(
 
   } else if (ros2mqtt.json) {  // publish as json string
 
-    // resolve ROS messages to primitive strings if possible
-    RosMsgParser::Parser parser(ros_topic, RosMsgParser::ROSType(ros2mqtt.ros.msg_type), RosMsgParser::GetMessageDefinition(ros2mqtt.ros.msg_type));
+    if (!ros2mqtt.ros.parser) {
+      // initialise json message parser
+      ros2mqtt.ros.parser = std::make_shared<RosMsgParser::Parser>(ros_topic, RosMsgParser::ROSType(ros2mqtt.ros.msg_type), RosMsgParser::GetMessageDefinition(ros2mqtt.ros.msg_type));
+    }
+
     RosMsgParser::NanoCDR_Deserializer deserializer;
     RosMsgParser::Span<const unsigned char> data{
         reinterpret_cast<const unsigned char*>(serialized_msg->get_rcl_serialized_message().buffer),
@@ -1030,7 +1033,7 @@ void MqttClient::ros2mqtt(
     };
 
     std::string payload;
-    parser.deserializeIntoJson(data, &payload, &deserializer);
+    ros2mqtt.ros.parser->deserializeIntoJson(data, &payload, &deserializer);
     payload_buffer = std::vector<uint8_t>(payload.begin(), payload.end());
 
   } else {  // publish as complete ROS message incl. ROS message type
@@ -1181,9 +1184,14 @@ void MqttClient::mqttjson2ros(mqtt::const_message_ptr mqtt_msg) {
   std::string mqtt_topic = mqtt_msg->get_topic();
   Mqtt2RosInterface& mqtt2ros = mqtt2ros_[mqtt_topic];
 
-  RosMsgParser::Parser parser(mqtt2ros.ros.topic, RosMsgParser::ROSType(mqtt2ros.ros.msg_type), RosMsgParser::GetMessageDefinition(mqtt2ros.ros.msg_type));
+  if (!mqtt2ros.ros.parser) {
+    // initialise json message parser
+    mqtt2ros.ros.parser = std::make_shared<RosMsgParser::Parser>(mqtt2ros.ros.topic, RosMsgParser::ROSType(mqtt2ros.ros.msg_type), RosMsgParser::GetMessageDefinition(mqtt2ros.ros.msg_type));
+  }
+
+
   RosMsgParser::ROS2_Serializer serializer;
-  parser.serializeFromJson(mqtt_msg->get_payload(), &serializer);
+  mqtt2ros.ros.parser->serializeFromJson(mqtt_msg->get_payload(), &serializer);
   uint32_t msg_length = serializer.getBufferSize();
 
   // copy ROS message from MQTT message to generic message buffer

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -467,7 +467,7 @@ void MqttClient::loadParameters() {
       if (ros2mqtt.json && !ros2mqtt.fixed_type) {
         RCLCPP_ERROR(
           get_logger(),
-          "ROS topic '%s' configured to publish as JSON must have a type configured", ros_topic.c_str());
+          "ROS topic '%s' configured to publish as JSON must have a 'ros_type' configured", ros_topic.c_str());
         exit(EXIT_FAILURE);
       }
 
@@ -592,7 +592,7 @@ void MqttClient::loadParameters() {
       if (mqtt2ros.json && !mqtt2ros.fixed_type) {
         RCLCPP_ERROR(
           get_logger(),
-          "MQTT topic '%s' configured to be read as JSON must have a type configured", mqtt_topic.c_str());
+          "MQTT topic '%s' configured to be read as JSON must have a 'ros_type' configured", mqtt_topic.c_str());
         exit(EXIT_FAILURE);
       }
 

--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -35,6 +35,8 @@ SOFTWARE.
 #include <mqtt_client/MqttClient.hpp>
 #include <mqtt_client_interfaces/msg/ros_msg_type.hpp>
 #include <rcpputils/env.hpp>
+#include <rosx_introspection/ros_parser.hpp>
+#include <rosx_introspection/ros_utils/ros2_helpers.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/char.hpp>
 #include <std_msgs/msg/float32.hpp>
@@ -50,8 +52,6 @@ SOFTWARE.
 #include <std_msgs/msg/u_int8.hpp>
 #include <std_msgs/msg/u_int8_multi_array.hpp>
 
-#include "rosx_introspection/ros_parser.hpp"
-#include "rosx_introspection/ros_utils/ros2_helpers.hpp"
 #include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(mqtt_client::MqttClient)
 


### PR DESCRIPTION
This adds the capability to configure the mqtt client to send/receive messages as JSON strings, allowing for better bidirectional support of arbitrary message types between ROS and non-ROS devices.

This takes heavy inspiration from #51 and would close #9.