### PR TITLE
Fix startup race: construct publishers before connecting MQTT broker

### DIFF
--- a/mqtt_client/src/MqttClient.cpp
+++ b/mqtt_client/src/MqttClient.cpp
@@ -654,6 +654,11 @@ void MqttClient::setup() {
   // initialize MQTT client
   setupClient();
 
+  // create ROS publishers BEFORE connect() so the Paho callback thread
+  // does not fire message_arrived against half-constructed publishers.
+  // See https://github.com/ika-rwth-aachen/mqtt_client (v2.4.1) startup race.
+  setupPublishers();
+
   // connect to MQTT broker
   connect();
 
@@ -677,8 +682,6 @@ void MqttClient::setup() {
   check_subscriptions_timer_ =
     create_wall_timer(std::chrono::duration<double>(1.0),
                       std::bind(&MqttClient::setupSubscriptions, this));
-
-  setupPublishers ();
 }
 
 std::optional<rclcpp::QoS> MqttClient::getCompatibleQoS (const std::string &ros_topic, const rclcpp::TopicEndpointInfo &tei,


### PR DESCRIPTION
## Summary

`MqttClient::setup()` currently calls `connect()` before `setupPublishers()`. Because `connect()` launches Paho's internal threads (network I/O + message-delivery callback), the delivery thread can fire `message_arrived()` while the main thread is still constructing the `rclcpp::GenericPublisher`s that `mqtt2ros()` is about to dereference. The result is an intermittent SIGSEGV in `rclcpp::PublisherBase::get_publisher_handle()` during normal operation.

This PR reorders `setup()` so publishers are fully constructed before `connect()` is called, closing the race window.

## The bug

In v2.4.1 (`fb83478`, also still present on `main` HEAD `8e061b3`):

```cpp
// MqttClient::setup() — mqtt_client/src/MqttClient.cpp
setupClient();    // installs *this as Paho callback
connect();        // line 658 — launches Paho threads, broker may deliver retained msgs immediately
... services / timer ...
setupPublishers();  // line 681 — too late; publisher construction races with mqtt2ros()
```

Once `connect()` returns, the broker can complete the connection at any moment. On `connack`, Paho's delivery thread enters `MqttClient::connected()` (line 1271), iterates `mqtt2ros_`, and calls `client_->subscribe()` for each configured topic. Any retained messages on those topics — common in deployments using the typesync protocol embedded in this client — start flowing through `message_arrived()` immediately:

```cpp
mqtt2ros(...)  // line 1059
  → mqtt2ros.ros.publisher->publish(serialized_msg)  // line 1113
```

Meanwhile, the main thread is still inside `setupPublishers()`, calling `create_generic_publisher()` and assigning to `mqtt2ros.ros.publisher`. That assignment is not atomic, and even when the read on the Paho thread observes the new pointer, the underlying `PublisherBase` / Fast-DDS `DataWriter` has not finished construction.

We hit this in production with a `mqtt_client` node bridging a remote system that publishes to one of our subscribed topics at ~100 Hz. A core dump captured the exact race:

```
Thread 1 (Paho delivery thread):
  rclcpp::PublisherBase::get_publisher_handle()    ← SIGSEGV
  rclcpp::GenericPublisher::publish()
  mqtt_client::mqtt2ros(...)
  mqtt_client::message_arrived(...)

Thread 4 (main thread):
  eprosima::fastdds::dds::DataWriterImpl::enable()  ← still constructing
  rclcpp::PublisherBase::PublisherBase(...)
  mqtt_client::setupPublishers()
  mqtt_client::setup()
  mqtt_client::MqttClient(rclcpp::NodeOptions const&)
```

Two threads operating on the same `PublisherBase` — one creating it, one dereferencing it. Crash signature is consistent across multiple incidents.

## The fix

Move `setupPublishers()` ahead of `connect()` in `setup()`:

```diff
   // initialize MQTT client
   setupClient();

+  // create ROS publishers BEFORE connect() so the Paho callback thread
+  // does not fire message_arrived against half-constructed publishers.
+  setupPublishers();
+
   // connect to MQTT broker
   connect();

   ...

   check_subscriptions_timer_ = create_wall_timer(...);
-
-  setupPublishers ();
 }
```

5 insertions, 2 deletions. Once publishers exist, the Paho thread reads stable pointers to fully constructed `PublisherBase` objects and `publish()` is well-defined.

## Scope (what this PR does NOT fix)

While reviewing the file we noticed several adjacent thread-safety issues that share the same root cause — no synchronization between the Paho callback thread and the main rclcpp thread:

- `is_connected_` is written from `connected()` / `connection_lost()` (Paho thread, lines 1275, 1508, 1519) and read from `isConnectedService()` (main thread, line 1311) without an atomic.
- `mqtt2ros_[mqtt_topic]` at line 1062 is bare `std::map::operator[]`. The map is not mutated after `loadParameters()` in our deployment, but if `~/new_mqtt2ros_bridge` is used at runtime the map is mutated from the main thread while being read from the Paho thread.
- `publish()` at lines 1113, 1226, 1277 has no null-check on `mqtt2ros.ros.publisher`. With this PR the pointer is always set before subscribes happen, so it should be non-null in practice, but a defensive null-check is cheap.
- The destructor doesn't synchronously stop the Paho callback thread before publishers are torn down. This produces a separate SIGSEGV on shutdown (we see it consistently when SIGINT'ing the node), but with a different stack trace.

These are intentionally out of scope for this PR.

## Verification

Tested on a ROS 2 Humble system (`ros-humble-mqtt-client` rebuilt from this branch):

| Scenario | Before fix | After fix |
| --- | --- | --- |
| Bridge node with remote 100 Hz publisher, 5-min run | SIGSEGV within 1–4 min | clean for 5+ min steady state |
| Same node left running after parent launch shutdown | n/a (killed by relaunch) | ran 13+ min processing live traffic without incident |

The `mqtt_client` node still SIGSEGVs on shutdown (separate destruction-time race noted above), but the runtime "node disappeared from ROS graph" symptom that this PR targets is gone.

## Related issues

`#24` and `#57` describe what looks like the same symptom obliquely; this PR is a concrete root-cause fix for that class of report.
